### PR TITLE
Silence warning that sbrk() is deprecated

### DIFF
--- a/common/libtarg.c
+++ b/common/libtarg.c
@@ -85,6 +85,7 @@ void *
 libtarg_sbrk(size_t inc)
 {
 #if defined(TARGET_HOST)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   return sbrk(inc);
 #elif defined(TARGET_SA)
   uint8_t *ptr = &__heap[__heap_ptr];


### PR DESCRIPTION
In Darwin sbrk() generates a warning because it is deprecated. Add a pragma to ignore.