### PR TITLE
Derive types from Clang, if available

### DIFF
--- a/common/libtarg.h
+++ b/common/libtarg.h
@@ -11,22 +11,48 @@
 #define CHAR_MAX 127
 #endif
 
+#define UCHAR_MAX   ((unsigned char)~0)
+#define USHRT_MAX   ((unsigned short)~0)
+#define UINT_MAX    (~0)
+#define ULONG_MAX   (~0ul)
+#define ULLONG_MAX  (~0ull)
+
+#if __clang__
+
+#define CHAR_BIT      __CHAR_BIT__
+#define SCHAR_MAX     __SCHAR_MAX__
+#define SHRT_MAX      __SHRT_MAX__
+#define INT_MAX       __INT_MAX__
+#define LONG_MAX      __LONG_MAX__
+#define LLONG_MAX     __LONG_LONG_MAX__
+
+/* size type */
+typedef unsigned long         size_t;
+
+/* signed */
+typedef __INT8_TYPE__   int8_t;
+typedef __INT16_TYPE__  int16_t;
+typedef __INT32_TYPE__  int32_t;
+typedef __INT64_TYPE__  int64_t;
+
+/* unsigned */
+typedef __UINT8_TYPE__  uint8_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __UINT32_TYPE__ uint32_t;
+typedef __UINT64_TYPE__ uint64_t;
+
+/* pointer as an int type */
+typedef __INTPTR_TYPE__  intptr_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+
+#else
+
 #define CHAR_BIT 8
-#define SCHAR_MIN (-128)
 #define SCHAR_MAX 127
-#define UCHAR_MAX 255
-#define SHRT_MIN  (-1-0x7fff)
 #define SHRT_MAX  0x7fff
-#define USHRT_MAX 0xffff
-#define INT_MIN  (-1-0x7fffffff)
 #define INT_MAX  0x7fffffff
-#define UINT_MAX 0xffffffffU
-#define LONG_MIN (-LONG_MAX-1)
 #define LONG_MAX __LONG_MAX
-#define ULONG_MAX (2UL*LONG_MAX+1)
-#define LLONG_MIN (-LLONG_MAX-1)
 #define LLONG_MAX  0x7fffffffffffffffLL
-#define ULLONG_MAX (2ULL*LLONG_MAX+1)
 
 /* size type */
 typedef unsigned long         size_t;
@@ -43,12 +69,21 @@ typedef unsigned short int    uint16_t;
 typedef unsigned int          uint32_t;
 typedef unsigned long int     uint64_t;
 
+/* pointer as an int type */
+typedef int64_t               intptr_t;
+typedef uint64_t              uintptr_t;
+
+#endif
+
+#define SCHAR_MIN     (-SCHAR_MAX - 1)
+#define SHRT_MIN      (-SHRT_MAX - 1)
+#define INT_MIN       (-INT_MAX - 1)
+#define LONG_MIN      (-LONG_MAX - 1)
+#define LLONG_MIN     (-LLONG_MAX - 1)
+
 /* floating point */
 typedef float                 float_t;
 typedef double                double_t;
-
-/* pointer as an uint type */
-typedef uint64_t              uintptr_t;
 
 /* benchmark completed successfully */
 void libtarg_success(void);

--- a/common/libtarg.h
+++ b/common/libtarg.h
@@ -27,7 +27,7 @@
 #define LLONG_MAX     __LONG_LONG_MAX__
 
 /* size type */
-typedef unsigned long         size_t;
+typedef __SIZE_TYPE__   size_t;
 
 /* signed */
 typedef __INT8_TYPE__   int8_t;


### PR DESCRIPTION
Use Clang's built-in types if available. I did this because of a type conflict for uint64_t, which is `long long` on Darwin.