### PR TITLE
Added TARGET=qemu-riscv64 and fixed data type mismatch bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,17 @@ TARGET_CLEAN = *.d ibex_simple_system_pcount.csv
 TARGET_EXCLUDES = anagram c-interp checkers lz-compress rho-factor rsa-cipher spelt2num
 TARGET_CONFIGURED = 1
 TARGET_REFEXT = out
+else ifeq ($(TARGET), qemu-riscv64)
+TARGET_CC = riscv64-unknown-linux-gnu-gcc
+TARGET_AR = riscv64-unknown-linux-gnu-ar
+TARGET_CFLAGS = -DTARGET_HOST -march=rv64gc -mabi=lp64d -static
+TARGET_LIBS =
+TARGET_SIM = qemu-riscv64 -cpu rv64,zba=true,zbb=true,zbc=true,zbs=true,v=true,zvfh=true,vlen=256
+TARGET_DIFF = diff
+TARGET_EXE = $(PROG)
+TARGET_CLEAN =
+TARGET_CONFIGURED = 1
+TARGET_REFEXT = out
 else
 # default is an unconfigured
 TARGET_CONFIGURED = 0
@@ -146,6 +157,8 @@ build: $(TARGET_EXE)
 
 $(TARGET_EXE): $(OBJS) $(LIBS)
 ifeq ($(TARGET), host)
+	$(TARGET_CC) $(CFLAGS) -o $@ $^ $(LIBS) $(TARGET_LIBS)
+else ifeq ($(TARGET), qemu-riscv64)
 	$(TARGET_CC) $(CFLAGS) -o $@ $^ $(LIBS) $(TARGET_LIBS)
 else ifeq ($(TARGET), standalone)
 	$(TARGET_CC) $(CFLAGS) -o $@ $^ $(LIBS) $(TARGET_LIBS)

--- a/cipher/cipher.c
+++ b/cipher/cipher.c
@@ -53,11 +53,11 @@ main(void)
     libmin_fail(2);
   
   libmin_printf("TEA Cipher results:\n");
-  libmin_printf("  plaintext:  0x%08lx 0x%08lx\n",
+  libmin_printf("  plaintext:  0x%08x 0x%08x\n",
 	       plaintext[0], plaintext[1]);
-  libmin_printf("  ciphertext: 0x%08lx 0x%08lx\n",
+  libmin_printf("  ciphertext: 0x%08x 0x%08x\n",
 	       ciphertext[0], ciphertext[1]);
-  libmin_printf("  newplain:   0x%08lx 0x%08lx\n",
+  libmin_printf("  newplain:   0x%08x 0x%08x\n",
 	       newplain[0], newplain[1]);
 
   libmin_success();


### PR DESCRIPTION
1. Added qemu-riscv64 platform. After compiling and testing, cipher has the following errors:

![image](https://github.com/user-attachments/assets/8327b8c6-af57-4815-b051-d7867315f1f6)

2. Fixed the cipher bug on qemu-riscv64:
When libmin_printf prints ciphertext using %lx in 64-bit environments, ciphertext[0] and ciphertext[1] are implicitly converted to unsigned long. Because:The most significant bit of ciphertext[0] = 0x9fe2c864 is 1.
A sign expansion occurred during the conversion, causing the higher 32 bits to be padded with 0xffffffff.

The element that requires the correct formatting of the string ciphertext is an unsigned int and should use %08x instead of %08lx