### PR TITLE
fix(donut): Fix `donut` not building on gcc v15+

### DIFF
--- a/donut/donut.c
+++ b/donut/donut.c
@@ -11,8 +11,8 @@
 
 
 
-             K;double sin()
-         ,cos();niam(){float A=
+             K;/*double sin
+         ,cos;*/niam(){float A=
        0,B=0,i,j,z[1760];char b[
      1760];printf("\x1b[2J");for(xx
   ){memset(b,32,1760);memset(z,0,7040)


### PR DESCRIPTION
The original obfuscated code provided function prototypes using the old K&R function declaration syntax for `sin` and `cos`. Support for these was removed in C23, which is now the default in GCC v15+.

Since the bringup-bench port anyway includes `libmin.h` which includes prototypes/declarations of the `libmin_sin`/`libmin_cos` functions, the now invalid declarations are no longer needed.

This removes said declarations by commenting them out in such a fashion as to maintain the overall formatting of the code ;)

Fixes #13