### PR TITLE
Add `perf_start`/`perf_stop` markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,21 @@ void *libtarg_sbrk(size_t inc);
 ```
 Once these four interfaces are implemented, all of the Bringup-Bench benchmarks can be built and run. To facilitate testing, the "TARGET=host" target defines the four required system interfaces by passing them on to the Linux OS. In addition, the repo also provides a standalone target "TARGET=sa" which only requires that the target support provbable memory.
 
+Optionally, the following two system calls can be implemented and enabled by defining `LIBTARG_PERF_HOOKS`:
+
+```c
+/* start perf-monitoring */
+void libtarg_start_perf();
+
+/* stop perf-monitoring */
+void libtarg_stop_perf();
+```
+
+These hooks, if enabled, are called at the beginning and end of each benchmark, and can be used for platform specific instrumentation and performance monitoring.
+
+For benchmarks where computation is self-contained, only the core computation is placed in between the markers. For all other benchmarks, the complete benchmark code is placed between the markers.
+
+
 ## Using the code-based read-only file system
 
 Using the code-based read-only file system, it is possible for a benchmark to access a read-only file that is incorporated into its code. To convert an input file to a read-only code-based file, use the following command (shown for the benchmark "anagram"):

--- a/ackermann/ackermann.c
+++ b/ackermann/ackermann.c
@@ -150,20 +150,28 @@ ack(unsigned x, unsigned y)
 int
 main(void)
 {
-	unsigned y,k; 
-
+  unsigned y, k;
+  unsigned result[AMAX + 1][AMAX + 1]; //[x][y]
   max_depth = 0;
-	for(k=0;k<=AMAX;k++)
-  {
-		libmin_printf("\nx+y=%d:\n\n",k);
-		for(y=0;y<=k;y++)
-    {
-		  depth = 0;  /* stack guard */
-			libmin_printf("A(%d,%d) = %d\n",k-y,y,ack(k-y,y));
-      if (depth > max_depth)
-        max_depth = depth;   
-		}
-	}
+
+  // Calculate:
+  libtarg_start_perf();
+  for (k = 0; k <= AMAX; k++) {
+    for (y = 0; y <= k; y++) {
+      depth = 0; /* stack guard */
+      result[k - y][y] = ack(k - y, y);
+      if (depth > max_depth) max_depth = depth;
+    }
+  }
+  libtarg_stop_perf();
+
+  // Print:
+  for (k = 0; k <= AMAX; k++) {
+    libmin_printf("\nx+y=%d:\n\n", k);
+    for (y = 0; y <= k; y++) {
+      libmin_printf("A(%d,%d) = %d\n", k - y, y, result[k - y][y]);
+    }
+  }
   libmin_printf("Max recursive depth = %u\n", max_depth);
 
   libmin_success();

--- a/audio-codec/audio-codec.c
+++ b/audio-codec/audio-codec.c
@@ -145,17 +145,20 @@ void decode(int16_t *out, uint8_t *in, size_t len)
  */
 static void test(int16_t *pcm, uint8_t *coded, int16_t *decoded, size_t len)
 {
+
+    libtarg_start_perf();
     /* run encode */
     encode(coded, pcm, len);
+
+    /* run decode */
+    decode(decoded, coded, len);
+    libtarg_stop_perf();
 
     /* check encode result */
     for (size_t i = 0; i < len; i++)
     {
         libmin_assert(coded[i] == r_coded[i]);
     }
-
-    /* run decode */
-    decode(decoded, coded, len);
 
     /* check decode result */
     for (size_t i = 0; i < len; i++)

--- a/avl-tree/avl-tree.c
+++ b/avl-tree/avl-tree.c
@@ -49,6 +49,8 @@ int main(int argc, char** argv)
     topsize = 25;
     tick = topsize / 20;
     
+    libtarg_start_perf();
+
     libmin_srand(42);
     libmin_printf("Start  -->  Finished\n");
     for(i = 0; i < topsize; i++) {
@@ -155,6 +157,8 @@ int main(int argc, char** argv)
     }
     
     MakeEmpty(tree);
+
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/bit-kernels/bit-kernels.c
+++ b/bit-kernels/bit-kernels.c
@@ -106,6 +106,7 @@ int main(void) {
     unsigned long long total_parallel = 0;
     
     // Process each number.
+    libtarg_start_perf();
     for (size_t i = 0; i < NUM_ELEMENTS; i++) {
         uint32_t val = numbers[i];
         unsigned int naive   = count_bits_naive(val);
@@ -133,6 +134,7 @@ int main(void) {
                    val, naive, kernighan, builtin, table, parallel);
         }
     }
+    libtarg_stop_perf();
     
     // Print overall totals for comparison.
     libmin_printf("\nTotal bit count over %d numbers:\n", NUM_ELEMENTS);

--- a/blake2b/blake2b.c
+++ b/blake2b/blake2b.c
@@ -424,7 +424,7 @@ static void assert_bytes(const uint8_t *expected, const uint8_t *actual,
  */
 static void test()
 {
-    uint8_t *digest = NULL;
+    libtarg_start_perf();
 
     /* "abc" example straight out of RFC-7693 */
     uint8_t abc[3] = {'a', 'b', 'c'};
@@ -436,10 +436,7 @@ static void test()
         0x45, 0x33, 0xCC, 0x95, 0x18, 0xD3, 0x8A, 0xA8, 0xDB, 0xF1, 0x92,
         0x5A, 0xB9, 0x23, 0x86, 0xED, 0xD4, 0x00, 0x99, 0x23};
 
-    digest = blake2b(abc, 3, NULL, 0, 64);
-    assert_bytes(abc_answer, digest, 64);
-
-    libmin_free(digest);
+    uint8_t *abc_digest= blake2b(abc, 3, NULL, 0, 64);
 
     uint8_t key[64] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
@@ -456,10 +453,7 @@ static void test()
         0x05, 0xf4, 0x2d, 0x2f, 0xf4, 0x23, 0x34, 0x99, 0x39, 0x16, 0x53,
         0xdf, 0x7a, 0xef, 0xcb, 0xc1, 0x3f, 0xc5, 0x15, 0x68};
 
-    digest = blake2b(NULL, 0, key, 64, 64);
-    assert_bytes(key_answer, digest, 64);
-
-    libmin_free(digest);
+    uint8_t *key_digest= blake2b(NULL, 0, key, 64, 64);
 
     uint8_t zero[1] = {0};
     uint8_t zero_key[64] = {
@@ -477,10 +471,7 @@ static void test()
         0x4e, 0xf9, 0xb0, 0xf3, 0x4c, 0x70, 0x03, 0xfa, 0xc0, 0x9a, 0x5e,
         0xf1, 0x53, 0x2e, 0x69, 0x43, 0x02, 0x34, 0xce, 0xbd};
 
-    digest = blake2b(zero, 1, zero_key, 64, 64);
-    assert_bytes(zero_answer, digest, 64);
-
-    libmin_free(digest);
+    uint8_t *zero_digest= blake2b(zero, 1, zero_key, 64, 64);
 
     uint8_t filled[64] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
@@ -504,10 +495,18 @@ static void test()
         0x68, 0xa6, 0xe5, 0x09, 0xe1, 0x19, 0xff, 0x07, 0x78, 0x7b, 0x3e,
         0xf4, 0x83, 0xe1, 0xdc, 0xdc, 0xcf, 0x6e, 0x30, 0x22};
 
-    digest = blake2b(filled, 64, filled_key, 64, 64);
-    assert_bytes(filled_answer, digest, 64);
+    uint8_t *filled_digest= blake2b(filled, 64, filled_key, 64, 64);
 
-    libmin_free(digest);
+    libtarg_stop_perf();
+
+    assert_bytes(abc_answer, abc_digest, 64);
+    libmin_free(abc_digest);
+    assert_bytes(key_answer, key_digest, 64);
+    libmin_free(key_digest);
+    assert_bytes(zero_answer, zero_digest, 64);
+    libmin_free(zero_digest);
+    assert_bytes(filled_answer, filled_digest, 64);
+    libmin_free(filled_digest);
 
     libmin_printf("INFO: All tests have successfully passed!\n");
 }

--- a/bloom-filter/bloom-filter.c
+++ b/bloom-filter/bloom-filter.c
@@ -33,13 +33,17 @@ main(void)
 	for(i = 0; i < NUM_ITEMS; i++)
 	{
 		filter_contents[i] = libmin_rand();
-		bfilter_add(bFilter, &filter_contents[i]);
-
 		// Fill our test array with a 50/50 mix of numbers that have been entered into the filter, and random numbers
 		if(libmin_rand() & 1)
 			test_array[i] = filter_contents[i];
 		else
 			test_array[i] = libmin_rand();
+	}
+
+	libtarg_start_perf();
+	for(i = 0; i < NUM_ITEMS; i++)
+	{
+		bfilter_add(bFilter, &filter_contents[i]);
 	}
 
 	for(i = 0; i < NUM_ITEMS; i++)
@@ -56,6 +60,7 @@ main(void)
 		else if(!array_present && filter_present)  false_positives++;
 		else if(array_present && !filter_present)  false_negatives++;
 	}
+	libtarg_stop_perf();
 
 	libmin_printf("True positives: %i\n"
 		"True negatives: %i\n"

--- a/boyer-moore-search/boyer-moore-search.c
+++ b/boyer-moore-search/boyer-moore-search.c
@@ -125,7 +125,9 @@ main(void)
 	
 
   // Run search
+  libtarg_start_perf();
   search(txt, n, pat, m, ret);
+  libtarg_stop_perf();
 
   // print results
   for(int i=0; i<n; i++)

--- a/bubble-sort/bubble-sort.c
+++ b/bubble-sort/bubble-sort.c
@@ -51,7 +51,10 @@ main(void)
     data[i] = libmin_rand();
   print_data(data, DATASET_SIZE);
 
+  libtarg_start_perf();
   bubblesort(data, DATASET_SIZE);
+  libtarg_stop_perf();
+
   print_data(data, DATASET_SIZE);
 
   // check the array

--- a/cipher/cipher.c
+++ b/cipher/cipher.c
@@ -45,12 +45,14 @@ int
 main(void)
 {
 
+  libtarg_start_perf();
   encipher(plaintext, ciphertext, keytext);
   if (ciphertext[0] != cipherref[0] || ciphertext[1] != cipherref[1])
     libmin_fail(1);
   decipher(ciphertext, newplain, keytext);
   if (newplain[0] != plaintext[0] || newplain[1] != plaintext[1])
     libmin_fail(2);
+  libtarg_stop_perf();
   
   libmin_printf("TEA Cipher results:\n");
   libmin_printf("  plaintext:  0x%08lx 0x%08lx\n",

--- a/connect4-minimax/connect4-minimax.c
+++ b/connect4-minimax/connect4-minimax.c
@@ -319,7 +319,9 @@ void play_game() {
 int main(void) {
     libmin_srand(42);
     libmin_printf("Connect Four: Minimax AI Self-Play\n");
+    libtarg_start_perf();
     play_game();
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/convex-hull/convex-hull.c
+++ b/convex-hull/convex-hull.c
@@ -82,6 +82,7 @@ int main() {
     points[minIdx] = temp;
     p0 = points[0];  // Set the global pivot.
 
+    libtarg_start_perf();
     // Sort the remaining points according to the polar angle relative to p0.
     sortPoints(points, NUM_POINTS);
 
@@ -99,6 +100,7 @@ int main() {
         }
         hull[hullSize++] = points[i];  // Push the current point.
     }
+    libtarg_stop_perf();
 
     // Print the convex hull result.
     libmin_printf("Convex Hull Points (in order):\n");

--- a/dhrystone/dhrystone.c
+++ b/dhrystone/dhrystone.c
@@ -173,6 +173,7 @@ main(void)
   /* Start timer */
   /***************/
 
+  libtarg_start_perf();
   for (Run_Index = 1; Run_Index <= Pnumber_of_runs; ++Run_Index)
   {
 
@@ -218,6 +219,7 @@ main(void)
       /* Int_1_Loc == 5 */
 
   } /* loop "for Run_Index" */
+  libtarg_stop_perf();
 
   /**************/
   /* Stop timer */

--- a/distinctness/distinctness.c
+++ b/distinctness/distinctness.c
@@ -169,8 +169,10 @@ main(void)
   int dup1, dup2;
   int res1, res2;
 
+  libtarg_start_perf();
   res1 = isDistinct(elements1, &dup1);
   res2 = isDistinct(elements2, &dup2);
+  libtarg_stop_perf();
 
   if (res1)
     libmin_printf("The elements of `elements1' are distinct\n");

--- a/fft-int/fft-int.c
+++ b/fft-int/fft-int.c
@@ -415,6 +415,8 @@ main(void)
     imag[i] = 0;
   }
 
+  libtarg_start_perf();
+
   fix_fft(real, imag, M, 0);
 
   for (i=0; i<N; i++)
@@ -424,6 +426,8 @@ main(void)
 
   for (i=0; i<N; i++)
     libmin_printf("%d: %d, %d\n", i, real[i], imag[i]);
+
+  libtarg_stop_perf();
 
   libmin_success();;
   return 0;

--- a/flood-fill/flood-fill.c
+++ b/flood-fill/flood-fill.c
@@ -147,7 +147,9 @@ main()
   libmin_printf("\nBEFORE flooding `%c' @ (%d,%d):\n", replacement, x, y); printMatrix(mat);
 
   // replace the target color with a replacement color using DFS
+  libtarg_start_perf();
   floodfill(mat, x, y, replacement);
+  libtarg_stop_perf();
 
   // print the colors after replacement
   libmin_printf("\nAFTER:\n"); printMatrix(mat);

--- a/frac-calc/frac-calc.c
+++ b/frac-calc/frac-calc.c
@@ -176,6 +176,8 @@ int main(int argc, char *argv[])
     char rep[SBUFF];
     int repi = 1;
 
+    libtarg_start_perf();
+
     /* IFDEBUG("Starting optarg loop..."); */
 
     /* getopt() configured options:
@@ -216,6 +218,7 @@ int main(int argc, char *argv[])
         repi = libmin_atoi(rep);
     }while(repi == 1);
 
+    libtarg_stop_perf();
     libmin_success();
     return 0;
 }

--- a/fuzzy-match/fuzzy-match.c
+++ b/fuzzy-match/fuzzy-match.c
@@ -309,6 +309,7 @@ const char *entries[] = {
 int
 main(void)
 {
+  libtarg_start_perf();
   {
 	  const char *pattern = "core";
     libmin_printf("Matches for `%s':\n", pattern);
@@ -347,6 +348,7 @@ main(void)
 	  }
     libmin_printf("\n");
   }
+  libtarg_stop_perf();
 
   libmin_success();	
   return 0;

--- a/fy-shuffle/fy-shuffle.c
+++ b/fy-shuffle/fy-shuffle.c
@@ -51,6 +51,7 @@ main(void)
   /* initialize random seed: */
   libmin_srand(42);
 
+  libtarg_start_perf();
   for (int k = 0; k < 8; k++)
   {
     print("A (before): ", a, SZ_A);
@@ -61,6 +62,7 @@ main(void)
     fy_shuffle(b, SZ_B);
     print("B (after):  ", b, SZ_B);
   }
+  libtarg_stop_perf();
   
   libmin_success();
   return 0;

--- a/gcd-list/gcd-list.c
+++ b/gcd-list/gcd-list.c
@@ -45,7 +45,9 @@ main(void)
   libmin_printf(" }\n");
 
   uint32_t gcd_of_n;
+  libtarg_start_perf();
   gcd_of_n = gcd(a, n);
+  libtarg_stop_perf();
   libmin_printf("GCD of list: %u\n", gcd_of_n);
 
   libmin_free(a);

--- a/grad-descent/grad-descent.c
+++ b/grad-descent/grad-descent.c
@@ -80,7 +80,10 @@ main(void)
 	double weight = 0;
 	double bias = 0;
 
+	libtarg_start_perf();
 	gradientDescent(&weight, &bias);
+	libtarg_stop_perf();
+
 	libmin_printf("The function is: %.4lfx + %.4lf\n", weight, bias);
 
   libmin_success();

--- a/graph-tests/graph-tests.c
+++ b/graph-tests/graph-tests.c
@@ -332,7 +332,7 @@ towers_test(void)
 int
 main(void)
 {
-
+    libtarg_start_perf();
     bfs_test();
 
     link_list();
@@ -340,6 +340,7 @@ main(void)
     DFS_test();
 
     towers_test();
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/hanoi/hanoi.c
+++ b/hanoi/hanoi.c
@@ -34,6 +34,7 @@ main(void)
 
   disk = 0;
 
+  libtarg_start_perf();
   while (1)
     {
       disk++;
@@ -50,6 +51,7 @@ main(void)
 
       if (disk == 10) break;
     }
+  libtarg_stop_perf();
 
   libmin_success();
   return 0;

--- a/heapsort/heapsort.c
+++ b/heapsort/heapsort.c
@@ -16,6 +16,8 @@ HSORT(int64_t m, int64_t p)
   int64_t  msize, iran, ia, ic, im, ih, ir;
   int64_t  count, ca;
 
+  libtarg_start_perf();
+
   msize = m * bplong;
   size  = m - 1;
 
@@ -80,6 +82,8 @@ HSORT(int64_t m, int64_t p)
     }
  Done:
   count = count + ca;
+
+  libtarg_stop_perf();
 
   /* Scale runtime per iteration */
   ir = count;

--- a/heat-calc/heat-calc.c
+++ b/heat-calc/heat-calc.c
@@ -21,6 +21,7 @@ int main() {
             u[i] = 0.0;
     }
 
+    libtarg_start_perf();
     // Main time-stepping loop: simulate STEPS time steps.
     for (step = 0; step < STEPS; step++) {
         // Update interior points using the explicit finite difference scheme:
@@ -39,20 +40,22 @@ int main() {
         }
     }
 
+    // Compute a simple checksum (sum of all temperatures) for validation.
+    double checksum = 0.0;
+    for (i = 0; i < N; i++) {
+        checksum += u[i];
+    }
+    libtarg_stop_perf();
+
     // Output the final temperature distribution.
     libmin_printf("Final temperature distribution along the rod:\n");
     for (i = 0; i < N; i++) {
         libmin_printf("u[%d] = %.2f\n", i, u[i]);
     }
 
-    // Compute a simple checksum (sum of all temperatures) for validation.
-    double checksum = 0.0;
-    for (i = 0; i < N; i++) {
-        checksum += u[i];
-    }
     libmin_printf("Checksum: %.2f\n", checksum);
 
-    libtarg_success();
+    libmin_success();
     return 0;
 }
 

--- a/huff-encode/huff-encode.c
+++ b/huff-encode/huff-encode.c
@@ -169,6 +169,7 @@ int main() {
     // Example input string to compress
     char input[] = "this is an example for huffman encoding";
     
+    libtarg_start_perf();
     // Count frequency of each character in input
     int freq[256] = {0};
     for (int i = 0; input[i]; i++) {
@@ -201,6 +202,15 @@ int main() {
     char arr[MAX_TREE_HT];
     generateCodes(root, arr, 0, codes);
     
+    // Encode input string
+    char encoded[1024] = {0};
+    encodeString(input, codes, encoded);
+
+    // Decode the encoded string
+    char decoded[1024] = {0};
+    decodeString(root, encoded, decoded);
+    libtarg_stop_perf();
+
     // Print generated Huffman codes
     libmin_printf("Huffman Codes:\n");
     for (int i = 0; i < 256; i++) {
@@ -209,9 +219,6 @@ int main() {
         }
     }
     
-    // Encode input string
-    char encoded[1024] = {0};
-    encodeString(input, codes, encoded);
     libmin_printf("\nEncoded string:\n%s\n", encoded);
     
     // Report compression metrics:
@@ -222,9 +229,6 @@ int main() {
     libmin_printf("Encoded size: %d bits\n", encodedBits);
     libmin_printf("Compression ratio: %.2f%%\n", (double)encodedBits / inputBits * 100);
     
-    // Decode the encoded string
-    char decoded[1024] = {0};
-    decodeString(root, encoded, decoded);
     libmin_printf("\nDecoded string:\n%s\n", decoded);
     
     // Check that the decompressed string matches the original input

--- a/idct-alg/idct-alg.c
+++ b/idct-alg/idct-alg.c
@@ -48,7 +48,10 @@ int main() {
 
     double output[N][N] = {0};
 
+    libtarg_start_perf();
     idct_2d(input, output);
+    libtarg_stop_perf();
+
     print_matrix(output, "IDCT Output");
 
     libmin_success();

--- a/indirect-test/indirect-test.c
+++ b/indirect-test/indirect-test.c
@@ -48,10 +48,12 @@ void (*pbar)(int (*pfoo)(int x)) = &bar;
 int
 main(void)
 {
+  libtarg_start_perf();
   int (*pfoo)(int) = &foo;
   (*pbar)(pfoo);
   (*pbar)(pfoo);
   (*pbar)(pfoo);
+  libtarg_stop_perf();
   libmin_printf("aglobal = %d\n", aglobal);
 
   libmin_success();

--- a/k-means/k-means.c
+++ b/k-means/k-means.c
@@ -329,7 +329,9 @@ static void test()
         observations[i].y = radius * libmin_sin(ang);
     }
     int k = 5;  // No of clusters
+    libtarg_start_perf();
     cluster* clusters = kMeans(observations, size, k);
+    libtarg_stop_perf();
     printEPS(observations, size, clusters, k);
     // Free the accquired memory
     libmin_free(observations);

--- a/kadane/kadane.c
+++ b/kadane/kadane.c
@@ -68,7 +68,9 @@ main(void)
  
   libmin_printf("Array size= %d\n", n);
 
+  libtarg_start_perf();
   max_sum = kadane(arr, n, &ends_at);
+  libtarg_stop_perf();
 
   libmin_printf("The maximum sum of a contiguous subarray is %d (ending at index %d)\n", max_sum, ends_at);
 

--- a/kepler/kepler.c
+++ b/kepler/kepler.c
@@ -339,10 +339,12 @@ main(void)
 	}
 	
 	/* Do selected calculation, and quit when accuracy is bettered. */
+	libtarg_start_perf();
 	while(libmin_fabs(E_old - (E = method(E_old,e,M,0))) >= derror){
 		E_old = E;
 		libmin_printf("n = %d\tE = %f\n",n++,sign*E);
 	}
+	libtarg_stop_perf();
 
   libmin_success();
 	return 0;

--- a/knapsack/knapsack.c
+++ b/knapsack/knapsack.c
@@ -64,8 +64,9 @@ main(void)
   int w = W;
   int K[N+1][W+1];
 
-
+  libtarg_start_perf();
   knapSack(wt, val, K);
+  libtarg_stop_perf();
 
 	libmin_printf("Max value: %d\n", K[n][W]);
 	

--- a/knights-tour/knights-tour.c
+++ b/knights-tour/knights-tour.c
@@ -59,7 +59,10 @@ solveKT(void)
 
     /* Start from 0,0 and explore all tours using
        solveKTUtil() */
-    if (solveKTUtil(0, 0, 1, sol, xMove, yMove) == 0) {
+    libtarg_start_perf();
+    int result = solveKTUtil(0, 0, 1, sol, xMove, yMove);
+    libtarg_stop_perf();
+    if (result == 0) {
         libmin_printf("Solution does not exist");
         return 0;
     }

--- a/life/life.c
+++ b/life/life.c
@@ -44,6 +44,7 @@ main(void)
 
   init();
   int running = TRUE;
+  libtarg_start_perf();
   while (running) {
     draw();
     //sleep(500);
@@ -52,6 +53,7 @@ main(void)
     if (iters == 80)
       running = FALSE;
   }
+  libtarg_stop_perf();
 
   libmin_success();
   return 0;

--- a/longdiv/longdiv.c
+++ b/longdiv/longdiv.c
@@ -247,6 +247,8 @@ main(void)
 
 	/* Do sanity checks on args */
 
+	libtarg_start_perf();
+
 	for(i=0; i<libmin_strlen(argv[1]); i++)
 		if(!isdigit(argv[1][i])){
 			libmin_printf("%s\n%s\n","longdiv: syntax error",
@@ -385,6 +387,7 @@ main(void)
 	  step++;
 
 	}  /* repeat with new dividend */
+	libtarg_stop_perf();
 
 	/* Add any necessary trailing zeros to quotient */
 	j = libmin_strlen(quotient);

--- a/lu-decomp/lu-decomp.c
+++ b/lu-decomp/lu-decomp.c
@@ -57,7 +57,9 @@ int main() {
     double L[N][N] = {0};
     double U[N][N] = {0};
 
+    libtarg_start_perf();
     lu_decomposition(A, L, U);
+    libtarg_stop_perf();
 
     print_matrix("A", A);
     print_matrix("L", L);

--- a/mandelbrot/mandelbrot.c
+++ b/mandelbrot/mandelbrot.c
@@ -31,6 +31,7 @@ main(void)
   libmin_printf("** Mandelbrot ASCII image\n");
   libmin_printf("** xres: %d, yres: %d\n", hxres, hyres);
 
+  libtarg_start_perf();
   for (hy=1; hy <= hyres; hy++)
     {
       for (hx=1; hx <= hxres; hx++)
@@ -54,6 +55,7 @@ main(void)
 	}
       libmin_printf("\n");
     }
+  libtarg_stop_perf();
 
   libmin_success();
   return 0;

--- a/matmult/matmult.c
+++ b/matmult/matmult.c
@@ -22,6 +22,7 @@ int main() {
         }
     }
 
+    libtarg_start_perf();
     // --- First Multiplication: Loop order (i, j, k) ---
     for (int i = 0; i < N; i++) {
         for (int j = 0; j < N; j++) {
@@ -39,6 +40,7 @@ int main() {
             }
         }
     }
+    libtarg_stop_perf();
 
     // --- Verification: Compare C and refC ---
     int error = 0;

--- a/max-subseq/max-subseq.c
+++ b/max-subseq/max-subseq.c
@@ -56,7 +56,9 @@ main(void)
   n = libmin_strlen(S2);
 
   libmin_printf("S1 : %s (%d) \nS2 : %s  (%d)\n", S1, m, S2, n);
+  libtarg_start_perf();
   lcsAlgo();
+  libtarg_stop_perf();
   libmin_printf("\n");
 
   libmin_success();

--- a/mersenne/mersenne.c
+++ b/mersenne/mersenne.c
@@ -135,6 +135,7 @@ main(void)
   int i, j;
     
   sgenrand(4357);
+  libtarg_start_perf();
   for (i=0,j=0; i<steps; i++)
     {
       if ((i % 100) == 0)
@@ -144,6 +145,7 @@ main(void)
 	    libmin_printf("\n");
 	}
     }
+  libtarg_stop_perf();
   libmin_printf("\n");
 
   libmin_success();

--- a/minspan/minspan.c
+++ b/minspan/minspan.c
@@ -209,7 +209,9 @@ main()
 	}
 	initializeData(graph);	
 	displayGraph(graph);
+  libtarg_start_perf();
   minSpanTree(graph,path);
+  libtarg_stop_perf();
 
 	// displayPath(source,destination,path);
 	// displayGraph1(graph, path);

--- a/monte-carlo/monte-carlo.c
+++ b/monte-carlo/monte-carlo.c
@@ -11,6 +11,7 @@ main(void)
   // Seed the random number generator
   libmin_srand(42);
 
+  libtarg_start_perf();
   for (int i = 0; i < NUM_SAMPLES; ++i)
   {
     // Generate random (x, y) point in [0, 1] × [0, 1]
@@ -24,6 +25,7 @@ main(void)
 
   // Estimate Pi
   double pi_estimate = 4.0 * count_inside_circle / NUM_SAMPLES;
+  libtarg_stop_perf();
 
   // Output result
   libmin_printf("Estimated Pi = %.8f\n", pi_estimate);

--- a/murmur-hash/murmur-hash.c
+++ b/murmur-hash/murmur-hash.c
@@ -86,26 +86,24 @@ murmurhash (const char *key, uint32_t len, uint32_t seed)
 int
 main(void)
 {
-    uint32_t seed = 0;
+  uint32_t seed = 0;
 
-    {
-      const char *key = "kinkajou"; // 0xb6d99cf8
-      uint32_t hash = murmurhash(key, (uint32_t)libmin_strlen(key), seed);
-      libmin_printf("murmurhash(\"%s\") = 0x%x\n", key, hash);
-    }
+  libtarg_start_perf();
+  const char *key_1 = "kinkajou"; // 0xb6d99cf8
+  uint32_t hash_1 = murmurhash(key_1, (uint32_t)libmin_strlen(key_1), seed);
 
-    {
-      const char *key = "The bringup-bench benchmark MURMUR made this.";
-      uint32_t hash = murmurhash(key, (uint32_t)libmin_strlen(key), seed);
-      libmin_printf("murmurhash(\"%s\") = 0x%x\n", key, hash);
-    }
+  const char *key_2 = "The bringup-bench benchmark MURMUR made this.";
+  uint32_t hash_2 = murmurhash(key_2, (uint32_t)libmin_strlen(key_2), seed);
 
-    {
-      const char *key = "It has to start somewhere, it has to start sometime, what better place than here? What better time than now?";
-      uint32_t hash = murmurhash(key, (uint32_t)libmin_strlen(key), seed);
-      libmin_printf("murmurhash(\"%s\") = 0x%x\n", key, hash);
-    }
+  const char *key_3 = "It has to start somewhere, it has to start sometime, what better place than "
+                      "here? What better time than now?";
+  uint32_t hash_3 = murmurhash(key_3, (uint32_t)libmin_strlen(key_3), seed);
+  libtarg_stop_perf();
 
-    libmin_success();
-    return 0;
+  libmin_printf("murmurhash(\"%s\") = 0x%x\n", key_1, hash_1);
+  libmin_printf("murmurhash(\"%s\") = 0x%x\n", key_2, hash_2);
+  libmin_printf("murmurhash(\"%s\") = 0x%x\n", key_3, hash_3);
+
+  libmin_success();
+  return 0;
 }

--- a/n-queens/n-queens.c
+++ b/n-queens/n-queens.c
@@ -41,7 +41,9 @@ main(void)
 {
   int *queens = (int *)libmin_malloc(BOARD_SIZE * sizeof(int));
 
+  libtarg_start_perf();
   solve(queens, 0);
+  libtarg_stop_perf();
 
   libmin_printf("Total solutions for %d-Queens: %d\n", BOARD_SIZE, solution_count);
 

--- a/natlog/natlog.c
+++ b/natlog/natlog.c
@@ -12,8 +12,10 @@ main(void)
   y = 1.0 + 1.0/steps;
   x = 1.0;
 
+  libtarg_start_perf();
   for(; steps > 0; steps--)
     x *= y;
+  libtarg_stop_perf();
 
   libmin_printf("natlog: e=%f\n", x);
 

--- a/nbody-sim/nbody-sim.c
+++ b/nbody-sim/nbody-sim.c
@@ -23,6 +23,7 @@ int main(void) {
     };
 
     // Time integration loop using Euler integration
+    libtarg_start_perf();
     for (int step = 0; step < NUM_STEPS; step++) {
         // Array to store computed accelerations for each particle
         double acc[N_BODIES][3] = { {0.0} };
@@ -62,6 +63,7 @@ int main(void) {
             bodies[i].pos[2] += bodies[i].vel[2] * DT;
         }
     }
+    libtarg_stop_perf();
 
     // Print final positions and velocities after the simulation
     libmin_printf("Final state after %d steps:\n", NUM_STEPS);

--- a/nr-solver/nr-solver.c
+++ b/nr-solver/nr-solver.c
@@ -76,14 +76,19 @@ double testdata[] = {
 int
 main(void)
 {
-  double root;
-  int converged;
+  double root[NTESTDATA];
+  int converged[NTESTDATA];
 
+  libtarg_start_perf();
   for (unsigned int i=0; i < NTESTDATA; i++)
   {
     sqrt_value = testdata[i];
-    root = rn_solver(&converged, 0.00001, 20, f, df);
-    libmin_printf("sqrt(%lf) == %lf (converged:%c)\n", sqrt_value, root, converged ? 't' : 'f');
+    root[i] = rn_solver(converged+i, 0.00001, 20, f, df);
+  }
+  libtarg_stop_perf();
+
+  for (unsigned int i=0; i < NTESTDATA; i++) {
+    libmin_printf("sqrt(%lf) == %lf (converged:%c)\n", testdata[i], root[i], converged[i] ? 't' : 'f');
   }
 
   libmin_success();

--- a/packet-filter/packet-filter.c
+++ b/packet-filter/packet-filter.c
@@ -95,6 +95,7 @@ int main() {
     
     int packetCounter = 0;
     
+    libtarg_start_perf();
     // Simulate packet processing.
     while (packetCounter < PACKET_COUNT) {
         Packet pkt = generate_packet();
@@ -106,6 +107,7 @@ int main() {
             print_packet(pkt);
         }
     }
+    libtarg_stop_perf();
     
     libmin_success();
     return 0;

--- a/parrondo/parrondo.c
+++ b/parrondo/parrondo.c
@@ -209,6 +209,8 @@ main(void)
 	for(i=0;i<3;i++)site_visits[i] = 0L;  /* initialize counters */
 	i=0;
 	libmin_printf("Simulating %d trials ...\n",trials);
+	
+	libtarg_start_perf();
 	while(i<trials){   /* Loop over trials */
 
 		/* reseed */
@@ -239,6 +241,7 @@ main(void)
 		n = 0L;
 		
 	}
+	libtarg_stop_perf();
 
 	n_bar = n_tot/((double)i);
 

--- a/pascal/pascal.c
+++ b/pascal/pascal.c
@@ -127,6 +127,7 @@ int main(void)
 
 	/* build the triangle */
 	
+	libtarg_start_perf();
 	triangle[0][0] = 1;
 	for(i=1;i<nrows;i++){
 		triangle[i][0] = 1;
@@ -143,6 +144,8 @@ int main(void)
 
 	/* make sure this value is even */
 	if(max_width % 2) max_width++;
+
+    libtarg_stop_perf();
 
 	/* Since each number is printed in a field max_width+2 wide
 	   and there are nrows numbers in the longest (bottom) row

--- a/pi-calc/pi-calc.c
+++ b/pi-calc/pi-calc.c
@@ -5,5 +5,5 @@
 // Details- http://stackoverflow.com/questions/20287513/can-anyone-make-heads-or-tales-of-this-spigot-algorithm-code-pitiny-c
 // Source- http://www.iwriteiam.nl/SigProgC.html#pi
  
-int a[52514],b,c=52514,d,e,f=1e4,g,h;int main(void){for(;(b=c-=14);h=libmin_printf("%04d",e+d/f))for(e=d%=f;(g=--b*2);d/=g)d=d*b+f*(h?a[b]:f/5),a[b]=d%--g;libmin_success(); return 0;}
+int a[52514],b,c=52514,d,e,f=1e4,g,h;int main(void){libtarg_start_perf();for(;(b=c-=14);h=libmin_printf("%04d",e+d/f))for(e=d%=f;(g=--b*2);d/=g)d=d*b+f*(h?a[b]:f/5),a[b]=d%--g;libtarg_stop_perf();libmin_success(); return 0;}
 

--- a/primal-test/primal-test.c
+++ b/primal-test/primal-test.c
@@ -143,6 +143,7 @@ main(void)
   libmin_srand(42);
 
   // locate primes in a stream of random numbers
+  libtarg_start_perf();
   {
     uint32_t val = 3;
     for (int i=0; i < 200; i++)
@@ -159,6 +160,7 @@ main(void)
       val = libmin_rand();
     } 
   }
+  libtarg_stop_perf();
 
   // print out the primes that were found
   libmin_printf("Primality tests found %d primes...\n", q_head);

--- a/priority-queue/priority-queue.c
+++ b/priority-queue/priority-queue.c
@@ -110,6 +110,7 @@ int main()
     printPQ(&pq);
 
     libmin_srand(42);
+    libtarg_start_perf();
     pq = newNode(4, 1);
     for (int i=0; i < 250; i++)
     {
@@ -117,6 +118,7 @@ int main()
       int val = libmin_rand() % 250;
       push(&pq, prio, val);
     }
+    libtarg_stop_perf();
     printPQ(&pq);
 
     libmin_success();

--- a/qsort-demo/qsort-demo.c
+++ b/qsort-demo/qsort-demo.c
@@ -160,10 +160,12 @@ sort_structs_example(void)
 int
 main(void)
 {
+    libtarg_start_perf();
     /* run all example functions */
     sort_integers_example();
     sort_cstrings_example();
     sort_structs_example();
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/qsort-test/qsort-test.c
+++ b/qsort-test/qsort-test.c
@@ -62,13 +62,8 @@ int main(void) {
         30, 31, 32, 33, 34, 35, 36, 37, 38, 39
     };
     size_t n1 = sizeof(test1) / sizeof(test1[0]);
+    libtarg_start_perf();
     libmin_qsort(test1, n1, sizeof(int), int_compare);
-    libmin_printf("Test 1: Sorted Random Integer Array (40 elements):\n");
-    print_array(test1, n1);
-    if (is_sorted(test1, n1))
-        libmin_printf("Test 1 passed: array sorted correctly.\n");
-    else
-        libmin_printf("Test 1 failed: array not sorted correctly.\n");
 
     /* ---------------------------
      * Test 2: Integer array with few duplicates (40 elements).
@@ -83,12 +78,6 @@ int main(void) {
     };
     size_t n2 = sizeof(test2) / sizeof(test2[0]);
     libmin_qsort(test2, n2, sizeof(int), int_compare);
-    libmin_printf("\nTest 2: Sorted Integer Array with Few Duplicates (40 elements):\n");
-    print_array(test2, n2);
-    if (is_sorted(test2, n2))
-        libmin_printf("Test 2 passed: duplicate elements sorted correctly.\n");
-    else
-        libmin_printf("Test 2 failed: duplicate elements not sorted correctly.\n");
 
     /* ---------------------------
      * Test 3: Already sorted integer array (40 elements).
@@ -100,12 +89,6 @@ int main(void) {
         test3[i] = i;
     }
     libmin_qsort(test3, 40, sizeof(int), int_compare);
-    libmin_printf("\nTest 3: Already Sorted Integer Array (40 elements):\n");
-    print_array(test3, 40);
-    if (is_sorted(test3, 40))
-        libmin_printf("Test 3 passed: array remains sorted.\n");
-    else
-        libmin_printf("Test 3 failed: already sorted array not sorted correctly.\n");
 
     /* ---------------------------
      * Test 4: Reverse sorted integer array (40 elements).
@@ -117,12 +100,6 @@ int main(void) {
         test4[i] = 39 - i;
     }
     libmin_qsort(test4, 40, sizeof(int), int_compare);
-    libmin_printf("\nTest 4: Sorted Reverse Order Integer Array (40 elements):\n");
-    print_array(test4, 40);
-    if (is_sorted(test4, 40))
-        libmin_printf("Test 4 passed: reverse sorted array sorted correctly.\n");
-    else
-        libmin_printf("Test 4 failed: reverse sorted array not sorted correctly.\n");
 
     /* ---------------------------
      * Test 5: String array (32 elements).
@@ -137,6 +114,36 @@ int main(void) {
     };
     size_t n_str = sizeof(test_strings) / sizeof(test_strings[0]);
     libmin_qsort(test_strings, n_str, sizeof(char *), string_compare);
+    libtarg_stop_perf();
+
+    libmin_printf("Test 1: Sorted Random Integer Array (40 elements):\n");
+    print_array(test1, n1);
+    if (is_sorted(test1, n1))
+        libmin_printf("Test 1 passed: array sorted correctly.\n");
+    else
+        libmin_printf("Test 1 failed: array not sorted correctly.\n");
+
+    libmin_printf("\nTest 2: Sorted Integer Array with Few Duplicates (40 elements):\n");
+    print_array(test2, n2);
+    if (is_sorted(test2, n2))
+        libmin_printf("Test 2 passed: duplicate elements sorted correctly.\n");
+    else
+        libmin_printf("Test 2 failed: duplicate elements not sorted correctly.\n");
+
+    libmin_printf("\nTest 3: Already Sorted Integer Array (40 elements):\n");
+    print_array(test3, 40);
+    if (is_sorted(test3, 40))
+        libmin_printf("Test 3 passed: array remains sorted.\n");
+    else
+        libmin_printf("Test 3 failed: already sorted array not sorted correctly.\n");
+
+    libmin_printf("\nTest 4: Sorted Reverse Order Integer Array (40 elements):\n");
+    print_array(test4, 40);
+    if (is_sorted(test4, 40))
+        libmin_printf("Test 4 passed: reverse sorted array sorted correctly.\n");
+    else
+        libmin_printf("Test 4 failed: reverse sorted array not sorted correctly.\n");
+
     libmin_printf("\nTest 5: Sorted String Array (32 elements):\n");
     print_string_array(test_strings, n_str);
     if (is_sorted_string_array(test_strings, n_str))

--- a/quaternions/quaternions.c
+++ b/quaternions/quaternions.c
@@ -252,10 +252,12 @@ quaternion quaternion_multiply(const quaternion *in_quat1,
 static void test()
 {
     quaternion quat = {{0.7071}, {{0.7071, 0.0, 0.0}}};
+    libtarg_start_perf();
     euler eul = euler_from_quat(&quat);
-    libmin_printf("Euler: %.4lf, %.4lf, %.4lf\n", eul.pitch, eul.roll, eul.yaw);
-
     quaternion test_quat = quat_from_euler(&eul);
+    libtarg_stop_perf();
+
+    libmin_printf("Euler: %.4lf, %.4lf, %.4lf\n", eul.pitch, eul.roll, eul.yaw);
     libmin_printf("Quaternion: %.4lf %+.4lf %+.4lf %+.4lf\n", test_quat.w,
            test_quat.dual.x, test_quat.dual.y, test_quat.dual.z);
 

--- a/rabinkarp-search/rabinkarp-search.c
+++ b/rabinkarp-search/rabinkarp-search.c
@@ -109,7 +109,9 @@ main(void)
     ret[i] = FALSE; 
 
   // Run search
+  libtarg_start_perf();
   search(txt, n, pat, m, ret);
+  libtarg_stop_perf();
 
   // print results
   for(int i=0; i<n; i++)

--- a/rand-test/rand-test.c
+++ b/rand-test/rand-test.c
@@ -120,11 +120,13 @@ int main(void) {
     // Seed the system's RNG for good_rand().
     libmin_srand(42);
 
+    libtarg_start_perf();
     // First test: Use the deliberately weak generator (bad_rand).
     run_tests("Bad (bad_rand())", bad_rand);
 
     // Second test: Use the system's standard rand() via good_rand.
     run_tests("Good (good_rand())", good_rand);
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/ransac/ransac.c
+++ b/ransac/ransac.c
@@ -90,7 +90,9 @@ int main(void) {
     int best_inlier_count = 0;
 
     // Run RANSAC to estimate the line parameters.
+    libtarg_start_perf();
     ransac_line_fitting(points, NUM_POINTS, &best_m, &best_b, &best_inlier_count);
+    libtarg_stop_perf();
 
     // Display the results.
     libmin_printf("RANSAC estimated line: y = %f * x + %f\n", best_m, best_b);

--- a/regex-parser/regex-parser.c
+++ b/regex-parser/regex-parser.c
@@ -633,6 +633,7 @@ int main()
     size_t nfailed = 0;
     size_t i;
 
+    libtarg_start_perf();
     for (i = 0; i < ntests; ++i)
     {
         pattern = test_vector[i][1];
@@ -668,6 +669,7 @@ int main()
             }
         }
     }
+    libtarg_stop_perf();
 
     // printf("\n");
     libmin_printf("%lu/%lu tests succeeded.\n", ntests - nfailed, ntests);

--- a/rle-compress/rle-compress.c
+++ b/rle-compress/rle-compress.c
@@ -65,24 +65,35 @@ char* run_length_encode(char* str) {
  * @returns void
  */
 static void test() {
-    char *in, *out;
-    in = "aaaaaaabbbaaccccdefaadr";
-    out = run_length_encode(in);
-    libmin_assert(!libmin_strcmp(out, "7a3b2a4c1d1e1f2a1d1r"));
-    libmin_printf("in: %s -> out: %s\n", in, out);
-    libmin_free(out);
- 
-    in = "lidjhvipdurevbeirbgipeahapoeuhwaipefupwieofb";
-    out = run_length_encode(in);
-    libmin_assert(!libmin_strcmp(out, "1l1i1d1j1h1v1i1p1d1u1r1e1v1b1e1i1r1b1g1i1p1e1a1h1a1p1o1e1u1h1w1a1i1p1e1f1u1p1w1i1e1o1f1b"));
-    libmin_printf("in: %s -> out: %s\n", in, out);
-    libmin_free(out);
+    char *in_1, *out_1;
+    char *in_2, *out_2;
+    char *in_3, *out_3;
 
-    in = "htuuuurwuquququuuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahghghrw";
-    out = run_length_encode(in);
-    libmin_assert(!libmin_strcmp(out, "1h1t4u1r1w1u1q1u1q1u1q3u76a1h1g1h1g1h1r1w"));
-    libmin_printf("in: %s -> out: %s\n", in, out);
-    libmin_free(out);
+    libtarg_start_perf();
+    in_1 = "aaaaaaabbbaaccccdefaadr";
+    out_1 = run_length_encode(in_1);
+
+    in_2 = "lidjhvipdurevbeirbgipeahapoeuhwaipefupwieofb";
+    out_2 = run_length_encode(in_2);
+
+    in_3 = "htuuuurwuquququuuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+           "aaaahghghrw";
+    out_3 = run_length_encode(in_3);
+    libtarg_stop_perf();
+
+    libmin_assert(!libmin_strcmp(out_1, "7a3b2a4c1d1e1f2a1d1r"));
+    libmin_printf("in: %s -> out: %s\n", in_1, out_1);
+    libmin_free(out_1);
+
+    libmin_assert(!libmin_strcmp(
+      out_2,
+      "1l1i1d1j1h1v1i1p1d1u1r1e1v1b1e1i1r1b1g1i1p1e1a1h1a1p1o1e1u1h1w1a1i1p1e1f1u1p1w1i1e1o1f1b"));
+    libmin_printf("in: %s -> out: %s\n", in_2, out_2);
+    libmin_free(out_2);
+
+    libmin_assert(!libmin_strcmp(out_3, "1h1t4u1r1w1u1q1u1q1u1q3u76a1h1g1h1g1h1r1w"));
+    libmin_printf("in: %s -> out: %s\n", in_3, out_3);
+    libmin_free(out_3);
 }
 
 /**

--- a/sat-solver/sat-solver.c
+++ b/sat-solver/sat-solver.c
@@ -102,7 +102,11 @@ int main() {
     
     printFormula();
 
-    if (solveSAT(1)) {
+    libtarg_start_perf();
+    int result =  solveSAT(1);
+    libtarg_stop_perf();
+
+    if (result) {
         libmin_printf("SAT solution found:\n");
         printAssignment();
         libtarg_success();

--- a/shortest-path/shortest-path.c
+++ b/shortest-path/shortest-path.c
@@ -107,7 +107,9 @@ main(void)
 
  
   // Print the solution
+  libtarg_start_perf();
   floydWarshall(graph);
+  libtarg_stop_perf();
  
   // Print the shortest distance matrix
   printSolution(dist);

--- a/sieve/sieve.c
+++ b/sieve/sieve.c
@@ -22,6 +22,7 @@ SIEVE(long m, long p)
   register long count,size;
   long j;
 
+  libtarg_start_perf();
   size  = m - 1;
 
   N_Prime   = 0L;
@@ -54,6 +55,8 @@ SIEVE(long m, long p)
 						
   N_Prime = j ;
   L_Prime = prime;
+
+  libtarg_stop_perf();
 
   if (p != 0L)
     libmin_printf("  %9ld   %8ld     %8ld\n",m,N_Prime,L_Prime);

--- a/simple-grep/simple-grep.c
+++ b/simple-grep/simple-grep.c
@@ -26,13 +26,25 @@ main(void)
     return 2;
   }
 
+  libtarg_start_perf();
   while (libmin_mgets(lineBuffer, BUFFER_LENGTH, fp))
   {
     // libmin_printf("%s\n", lineBuffer);
     if (libmin_strstr(lineBuffer, av[2]))
     {
-      libmin_printf("%s", lineBuffer);
       ++count;
+    }
+  }
+  libtarg_stop_perf();
+
+  // Reopen and print matching lines
+  libmin_mclose(fp);
+  libmin_mopen(&speech, "r");
+  while (libmin_mgets(lineBuffer, BUFFER_LENGTH, fp))
+  {
+    if (libmin_strstr(lineBuffer, av[2]))
+    {
+      libmin_printf("%s", lineBuffer);
     }
   }
   libmin_mclose(fp);

--- a/spirograph/spirograph.c
+++ b/spirograph/spirograph.c
@@ -73,7 +73,9 @@ void test(void)
     double *x = (double *)libmin_malloc(N * sizeof(double));
     double *y = (double *)libmin_malloc(N * sizeof(double));
 
+    libtarg_start_perf();
     spirograph(x, y, l, k, N, rot);
+    libtarg_stop_perf();
 
     for (size_t i = 0; i < N; i++)
     {

--- a/sudoku-solver/sudoku-solver.c
+++ b/sudoku-solver/sudoku-solver.c
@@ -90,7 +90,11 @@ int main() {
     libmin_printf("Initial Sudoku Puzzle:\n");
     printBoard();
 
-    if (solveSudoku()) {
+    libtarg_start_perf();
+    int solved = solveSudoku();
+    libtarg_stop_perf();
+
+    if (solved) {
         libmin_printf("\nSolved Sudoku Puzzle:\n");
         printBoard();
         libtarg_success();

--- a/target/libtarg.c
+++ b/target/libtarg.c
@@ -249,3 +249,12 @@ libtarg_sbrk(size_t inc)
 #endif
 }
 
+#ifdef LIBTARG_PERF_HOOKS
+void libtarg_start_perf() {
+/* optional hook for starting perfomance monitoring/instrumentation */
+}
+
+void libtarg_stop_perf() {
+/* optional hook for starting perfomance monitoring/instrumentation */
+}
+#endif /* LIBTARG_PERF_HOOKS */

--- a/target/libtarg.h
+++ b/target/libtarg.h
@@ -130,4 +130,17 @@ void libtarg_putc(char c);
 /* get some memory */
 void *libtarg_sbrk(size_t inc);
 
+#ifdef LIBTARG_PERF_HOOKS
+/* start perf-monitoring */
+void libtarg_start_perf();
+
+/* stop perf-monitoring */
+void libtarg_stop_perf();
+#else
+
+#define libtarg_start_perf()
+#define libtarg_stop_perf()
+
+#endif /* LIBTARG_PERF_HOOKS */
+
 #endif /* LIBTARG_H */

--- a/tetris-sim/tetris-sim.c
+++ b/tetris-sim/tetris-sim.c
@@ -304,6 +304,7 @@ int main(void) {
     int move_count = 0;
     int total_lines_cleared = 0;
 
+    libtarg_start_perf();
     while (1) {
         const Piece *piece = random_piece();
         const Orientation *best_ori;
@@ -327,6 +328,7 @@ int main(void) {
     }
     libmin_printf("Game over after %d moves, total lines cleared: %d\n", move_count, total_lines_cleared);
     print_board(board);
+    libtarg_stop_perf();
 
     libmin_success();
     return 0;

--- a/tiny-NN/tiny-NN.c
+++ b/tiny-NN/tiny-NN.c
@@ -132,6 +132,8 @@ int train(NETWORK_DATA_TYPE eta, NETWORK_DATA_TYPE error_threshold, NETWORK_DATA
 	//train the network
 	unsigned int iteration_count = 0;
 
+	libtarg_start_perf();
+
 	while(total_error > error_threshold && iteration_count < MAX_ITERATIONS)
 	{
 		total_error = 0;//hmmm....
@@ -198,6 +200,8 @@ int train(NETWORK_DATA_TYPE eta, NETWORK_DATA_TYPE error_threshold, NETWORK_DATA
 		libmin_printf("iteration %d Total error %f\n",iteration_count,total_error);
 		#endif
 	}
+
+	libtarg_stop_perf();
 
 	return EXIT_SUCCESS;
 }

--- a/topo-sort/topo-sort.c
+++ b/topo-sort/topo-sort.c
@@ -93,7 +93,9 @@ void topologicalSort(struct Graph* graph)
     for (int i = 0; i < graph->V; ++i) { 
         visited[i] = FALSE; 
     } 
-  
+
+    libtarg_start_perf();
+
     // Call the recursive helper function to store 
     // Topological Sort starting from all vertices one by 
     // one 
@@ -102,7 +104,9 @@ void topologicalSort(struct Graph* graph)
             topologicalSortUtil(graph, i, visited, &stack); 
         } 
     } 
-  
+
+    libtarg_stop_perf();
+
     // Print contents of stack 
     while (stack != NULL) { 
         libmin_printf("%d ", stack->data); 

--- a/totient/totient.c
+++ b/totient/totient.c
@@ -172,7 +172,11 @@ main(void)
 		return 1;
 	}
 
-	libmin_printf("phi(%d) = %d\n",n,phi(n));
+	libtarg_start_perf();
+	int result = phi(n);
+	libtarg_stop_perf();
+
+	libmin_printf("phi(%d) = %d\n",n,result);
 
   libmin_success();
 	return 0;

--- a/uniquify/uniquify.c
+++ b/uniquify/uniquify.c
@@ -60,8 +60,21 @@ int main(void) {
     }
     libmin_printf("\n");
 
+    libtarg_start_perf();
     /* Sort the list using qsort from qsort.h/qsort.c */
     libmin_qsort(strings, n, sizeof(char *), string_compare);
+
+    /* Count unique strings */
+    size_t unique_count = 0;
+    if (n > 0) {
+        unique_count = 1;
+        for (size_t i = 1; i < n; i++) {
+            if (libmin_strcmp(strings[i], strings[i - 1]) != 0) {
+                unique_count++;
+            }
+        }
+    }
+    libtarg_stop_perf();
 
     libmin_printf("Sorted Strings:\n");
     for (size_t i = 0; i < n; i++) {
@@ -76,11 +89,9 @@ int main(void) {
     libmin_printf("Unique Strings:\n");
     if (n > 0) {
         libmin_printf("%s\n", strings[0]);
-        size_t unique_count = 1;
         for (size_t i = 1; i < n; i++) {
             if (libmin_strcmp(strings[i], strings[i - 1]) != 0) {
                 libmin_printf("%s\n", strings[i]);
-                unique_count++;
             }
         }
         libmin_printf("\nTotal Unique Strings: %u\n", unique_count);

--- a/vectors-3d/vectors-3d.c
+++ b/vectors-3d/vectors-3d.c
@@ -306,30 +306,36 @@ static void test()
 {
     vec_3d a = {1., 2., 3.};
     vec_3d b = {1., 1., 1.};
-    double d;
+    double d1, d2, dot_result, alpha;
+    vec_3d c;
 
+    // Perform all computations
+    libtarg_start_perf();
+    d1 = vector_norm(&a);
+    d2 = vector_norm(&b);
+    dot_result = dot_prod(&a, &b);
+    c = vector_prod(&a, &b);
+    alpha = get_angle(&a, &b);
+    libtarg_stop_perf();
+
+    // Print results and verify
     libmin_printf("%s", print_vector(&a, "a"));
     libmin_printf("%s", print_vector(&b, "b"));
 
-    d = vector_norm(&a);
-    libmin_printf("|a| = %.4lf\n", d);
-    libmin_assert(libmin_fabs(d - 3.742) < 0.01);
-    d = vector_norm(&b);
-    libmin_printf("|b| = %.4lf\n", d);
-    libmin_assert(libmin_fabs(d - 1.732) < 0.01);
+    libmin_printf("|a| = %.4lf\n", d1);
+    libmin_assert(libmin_fabs(d1 - 3.742) < 0.01);
+    libmin_printf("|b| = %.4lf\n", d2);
+    libmin_assert(libmin_fabs(d2 - 1.732) < 0.01);
 
-    d = dot_prod(&a, &b);
-    libmin_printf("Dot product: %lf\n", d);
-    libmin_assert(libmin_fabs(d - 6.0) < 0.01);
+    libmin_printf("Dot product: %lf\n", dot_result);
+    libmin_assert(libmin_fabs(dot_result - 6.0) < 0.01);
 
-    vec_3d c = vector_prod(&a, &b);
     libmin_printf("Vector product ");
     libmin_printf("%s", print_vector(&c, "c"));
     libmin_assert(libmin_fabs(c.x - (-1.0)) < 0.01);
     libmin_assert(libmin_fabs(c.y - (2.0)) < 0.01);
     libmin_assert(libmin_fabs(c.z - (-1.0)) < 0.01);
 
-    double alpha = get_angle(&a, &b);
     libmin_printf("The angle is %lf\n", alpha);
     libmin_assert(libmin_fabs(alpha - 0.387597) < 0.01);
 

--- a/weekday/weekday.c
+++ b/weekday/weekday.c
@@ -13,10 +13,17 @@ main(int argc, char** argv)
 {
   const char *days[7]={"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 
-  libmin_printf("%02d/%02d/%04d was a `%s'\n", 2, 20, 2024, days[dayOfWeek(2024, 2, 20)]);
-  libmin_printf("%02d/%02d/%04d was a `%s'\n", 4, 5, 1994, days[dayOfWeek(1994, 4, 5)]);
-  libmin_printf("%02d/%02d/%04d was a `%s'\n", 1, 1, 1975, days[dayOfWeek(1975, 1, 1)]);
-  libmin_printf("%02d/%02d/%04d was a `%s'\n", 2, 7, 1964, days[dayOfWeek(1964, 2, 7)]);
+  libtarg_start_perf();
+  int result1 = dayOfWeek(2024, 2, 20);
+  int result2 = dayOfWeek(1994, 4, 5);
+  int result3 = dayOfWeek(1975, 1, 1);
+  int result4 = dayOfWeek(1964, 2, 7);
+  libtarg_stop_perf();
+
+  libmin_printf("%02d/%02d/%04d was a `%s'\n", 2, 20, 2024, days[result1]);
+  libmin_printf("%02d/%02d/%04d was a `%s'\n", 4, 5, 1994, days[result2]);
+  libmin_printf("%02d/%02d/%04d was a `%s'\n", 1, 1, 1975, days[result3]);
+  libmin_printf("%02d/%02d/%04d was a `%s'\n", 2, 7, 1964, days[result4]);
 
   libmin_success();
   return 0;


### PR DESCRIPTION
On a few occasions I have had a need to start/stop platform-specific monitoring/performance counters for each of the benchmarks. 

This PR first adds two new optional `libtarg` hooks, which are only enabled/used if `LIBTARG_PERF_HOOKS` is defined. This way the feature is opt-in and does not break any existing ports.

In the second commit I add said markers to all benchmarks. For benchmarks where computation and setup/validation/printing are fairly separate (or were simple to separate), the perf markers only wrap the core computation. For other benchmarks, the complete benchmark is wrapped in between the perf markers.

Please feel free to shut this down if this is not something you want to support in bringup-bench.