### PR TITLE
fix(libmin,target): Annoate `fail` hooks as noreturn.

### DIFF
--- a/common/libmin.h
+++ b/common/libmin.h
@@ -85,7 +85,7 @@ int libmin_sscanf(const char *buf, const char *fmt, ...);
 void libmin_success(void);
 
 /* exit co-simulation with failure exit code CODE */
-void libmin_fail(int code);
+NORETURN void libmin_fail(int code);
 
 /* largest random number, must be power-of-two-minus-one! */
 #define RAND_MAX (0x7fffffff)

--- a/common/libmin_fail.c
+++ b/common/libmin_fail.c
@@ -1,7 +1,7 @@
 #include "libmin.h"
 #include "libtarg.h"
 
-void
+NORETURN void
 libmin_fail(int code)
 {
   libmin_printf("ERROR: failure with termination code `%d'\n", code);

--- a/target/libtarg.c
+++ b/target/libtarg.c
@@ -36,7 +36,7 @@ simple_putchar(char c)
   return c;
 }
 
-extern inline void
+NORETURN extern inline void
 simple_halt(void)
 {
   SIMPLE_DEV_WRITE(SIMPLE_CTRL_BASE + SIMPLE_CTRL_CTRL, 1);
@@ -158,7 +158,7 @@ SPIN_SUCCESS_ADDR:
 }
 
 /* benchmark completed with error CODE */
-void
+NORETURN void
 libtarg_fail(int code)
 {
 #ifdef TARGET_HOST

--- a/target/libtarg.h
+++ b/target/libtarg.h
@@ -113,6 +113,21 @@ typedef uint64_t              uintptr_t;
 #define FLT_MAX        3.4028234663852886e+38
 #define FLT_MIN        1.1754943508222875e-38
 
+/* no-return attribute */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    /* C11 standard */
+    #include <stdnoreturn.h>
+    #define NORETURN noreturn
+#elif defined(__GNUC__) || defined(__clang__)
+    /* GCC or Clang */
+    #define NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+    /* Microsoft Visual C++ */
+    #define NORETURN __declspec(noreturn)
+#else
+    /* Fallback for unsupported compilers */
+    #define NORETURN
+#endif
 
 /* floating point */
 typedef float                 float_t;
@@ -122,7 +137,7 @@ typedef double                double_t;
 void libtarg_success(void);
 
 /* benchmark completed with error CODE */
-void libtarg_fail(int code);
+NORETURN void libtarg_fail(int code);
 
 /* output a single character, to whereever the target wants to send it... */
 void libtarg_putc(char c);


### PR DESCRIPTION
Modern compilers warn about array-out-of-bounds errors because they don't know that `libmin_fail` does not return and therefor prevents access to the `a` array if the check fails:
```
ackermann.c:141:14: error: array subscript 65535 is above array bounds of ‘unsigned int[65535][16]’ [-Werror=array-bounds=]
  141 |         if (a[x][y])
      |             ~^~~
```

This adds (unused) returns that silence the warnings.

In theory `libmin_fail` could be marked as no-return, but that is compiler-specific/not very portable.

----

Edit: Making the function `noreturn` is a better solution. I updated this PR.

