### PR TITLE
fix(spelt2num): Silence `maybe uninitialized` warnings

### DIFF
--- a/spelt2num/Makefile
+++ b/spelt2num/Makefile
@@ -1,5 +1,5 @@
 
-LOCAL_CFLAGS=
+LOCAL_CFLAGS=-Wno-maybe-uninitialized
 LOCAL_LIBS=
 LOCAL_OBJS=spelt2num.o
 


### PR DESCRIPTION
The initialization of `e` is too obfuscated for compilers to detect.