### PR TITLE
cva6: enable machine-mode exception reporting and RV64 CSR printing

### DIFF
--- a/target/cva6-crt0.S
+++ b/target/cva6-crt0.S
@@ -4,12 +4,8 @@
 
 .section .text.init
 
-#ifdef notdef
 default_exc_handler:
   jal x0, _cva6_exc_handler
-
-timer_handler:
-  jal x0, _cva6_timer_handler
 
 reset_handler:
   /* set all registers to zero */
@@ -46,8 +42,6 @@ reset_handler:
   mv x31, x1
 
   /* fall thru to stack initilization */
-#endif /* notdef */
-
 _start:
   .global _start
 
@@ -58,7 +52,13 @@ _start:
   li t0, (8*4096)
   add sp, sp, t0
 
-#ifdef notdef
+  /* Route all traps/exceptions to our machine-mode handler. */
+  .option push
+  .option norelax
+  la t0, default_exc_handler
+  .option pop
+  csrw mtvec, t0
+
   /* clear BSS */
   la x26, _bss_start
   la x27, _bss_end
@@ -66,11 +66,10 @@ _start:
   bge x26, x27, zero_loop_end
 
 zero_loop:
-  sw x0, 0(x26)
-  addi x26, x26, 4
+  sd x0, 0(x26)
+  addi x26, x26, 8
   blt x26, x27, zero_loop
 zero_loop_end:
-#endif /* notdef */
 
   /* jump to main program entry point (argc = argv = 0) */
   addi x10, x0, 0
@@ -79,25 +78,3 @@ zero_loop_end:
 
   /* if we return from main, call exit() */
   tail _cva6_exit
-
-#ifdef notdef
-/* =================================================== [ exceptions ] === */
-/* This section has to be down here, since we have to disable rvc for it  */
-
-  .section .vectors, "ax"
-  .option norvc;
-
-  // All unimplemented interrupts/exceptions go to the default_exc_handler.
-  .org 0x00
-  .rept 7
-  jal x0, default_exc_handler
-  .endr
-  jal x0, timer_handler
-  .rept 23
-  jal x0, default_exc_handler
-  .endr
-
-  // reset vector
-  .org 0x80
-  jal x0, reset_handler
-#endif /* notdef */

--- a/target/libtarg.c
+++ b/target/libtarg.c
@@ -159,26 +159,26 @@ memcpy(void *dest, const void *src, size_t len)
 // NOTE: If you change stack size, you must also update the cva6-crt0.S file.
 uint8_t _boot_stack[8*4096] __attribute__((aligned(16)));
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mepc(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mepc;" : "=r"(result));
   return result;
 }
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mcause(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mcause;" : "=r"(result));
   return result;
 }
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mtval(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mtval;" : "=r"(result));
   return result;
 }
@@ -188,7 +188,8 @@ _cva6_exc_handler(void)
 {
   libmin_printf("EXCEPTION!!!\n");
   libmin_printf("============\n");
-  libmin_printf("MEPC:0x%08x, CAUSE:0x%08x, MTVAL:0x%08x\n", _cva6_get_mepc(), _cva6_get_mcause(), _cva6_get_mtval());
+  libmin_printf("MEPC:0x%016lx, CAUSE:0x%016lx, MTVAL:0x%016lx\n",
+                _cva6_get_mepc(), _cva6_get_mcause(), _cva6_get_mtval());
 
   _cva6_exit(-1);
 }
@@ -399,4 +400,3 @@ libtarg_stop_perf(void)
 #endif
 }
 #endif /* TARGET_PERFHOOKS */
-


### PR DESCRIPTION
### Motivation
- The CVA6 RV64GC target was not routing traps to the software handler and was printing 32-bit CSR values, which prevented applications from reporting and terminating on unexpected RISC‑V exceptions.
- The goal is to ensure bringup-bench applications see full RV64 exception context (`mepc`, `mcause`, `mtval`) and reliably terminate when an exception occurs.

### Description
- In `target/cva6-crt0.S` program `mtvec` during `_start` to point at the `default_exc_handler` so all traps go to the machine-mode handler via `csrw mtvec, t0` and the handler `jal` remains at `default_exc_handler`.
- Re-enabled early `.bss` clearing in `target/cva6-crt0.S` and changed it to use RV64 stores (`sd`) and an 8-byte stride to correctly zero memory on RV64.
- In `target/libtarg.c` widened CSR accessors `_cva6_get_mepc`, `_cva6_get_mcause`, and `_cva6_get_mtval` to return `uint64_t` and updated the exception print call to use full 64-bit hex formatting (`%016lx`).
- Ensure the exception handlers print diagnostic CSR values and call the existing `_cva6_exit(-1)` exit path so the test harness can observe termination.

### Testing
- Ran `cd ackermann && make TARGET=cva6-rv64gc clean build` to validate integration, but the build failed because the cross toolchain binary `riscv-none-elf-gcc` is not installed in this environment, so no binary execution was performed.
- No other automated tests were run in this environment due to the missing cross toolchain; the source changes are self-contained and suitable for verification once the RV64 cross toolchain and CVA6 simulator are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb712dbc28832597d864f5e610b0c6)