### PR TITLE
Enable CVA6 RV64GC trap vector and 64-bit exception diagnostics

### DIFF
--- a/target/cva6-crt0.S
+++ b/target/cva6-crt0.S
@@ -4,49 +4,11 @@
 
 .section .text.init
 
-#ifdef notdef
-default_exc_handler:
-  jal x0, _cva6_exc_handler
-
-timer_handler:
-  jal x0, _cva6_timer_handler
-
-reset_handler:
-  /* set all registers to zero */
-  mv  x1, x0
-  mv  x2, x1
-  mv  x3, x1
-  mv  x4, x1
-  mv  x5, x1
-  mv  x6, x1
-  mv  x7, x1
-  mv  x8, x1
-  mv  x9, x1
-  mv x10, x1
-  mv x11, x1
-  mv x12, x1
-  mv x13, x1
-  mv x14, x1
-  mv x15, x1
-  mv x16, x1
-  mv x17, x1
-  mv x18, x1
-  mv x19, x1
-  mv x20, x1
-  mv x21, x1
-  mv x22, x1
-  mv x23, x1
-  mv x24, x1
-  mv x25, x1
-  mv x26, x1
-  mv x27, x1
-  mv x28, x1
-  mv x29, x1
-  mv x30, x1
-  mv x31, x1
-
-  /* fall thru to stack initilization */
-#endif /* notdef */
+/* Trap vector entry for CVA6.
+ * Keep this tiny and always tail-call into C to print/terminate.
+ */
+_cva6_trap_entry:
+  j _cva6_exc_handler
 
 _start:
   .global _start
@@ -58,7 +20,10 @@ _start:
   li t0, (8*4096)
   add sp, sp, t0
 
-#ifdef notdef
+  /* Route all traps/exceptions to _cva6_trap_entry in direct mode. */
+  la t0, _cva6_trap_entry
+  csrw mtvec, t0
+
   /* clear BSS */
   la x26, _bss_start
   la x27, _bss_end
@@ -70,7 +35,6 @@ zero_loop:
   addi x26, x26, 4
   blt x26, x27, zero_loop
 zero_loop_end:
-#endif /* notdef */
 
   /* jump to main program entry point (argc = argv = 0) */
   addi x10, x0, 0
@@ -79,25 +43,3 @@ zero_loop_end:
 
   /* if we return from main, call exit() */
   tail _cva6_exit
-
-#ifdef notdef
-/* =================================================== [ exceptions ] === */
-/* This section has to be down here, since we have to disable rvc for it  */
-
-  .section .vectors, "ax"
-  .option norvc;
-
-  // All unimplemented interrupts/exceptions go to the default_exc_handler.
-  .org 0x00
-  .rept 7
-  jal x0, default_exc_handler
-  .endr
-  jal x0, timer_handler
-  .rept 23
-  jal x0, default_exc_handler
-  .endr
-
-  // reset vector
-  .org 0x80
-  jal x0, reset_handler
-#endif /* notdef */

--- a/target/libtarg.c
+++ b/target/libtarg.c
@@ -159,26 +159,26 @@ memcpy(void *dest, const void *src, size_t len)
 // NOTE: If you change stack size, you must also update the cva6-crt0.S file.
 uint8_t _boot_stack[8*4096] __attribute__((aligned(16)));
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mepc(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mepc;" : "=r"(result));
   return result;
 }
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mcause(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mcause;" : "=r"(result));
   return result;
 }
 
-extern inline uint32_t
+extern inline uint64_t
 _cva6_get_mtval(void)
 {
-  uint32_t result;
+  uint64_t result;
   __asm__ volatile("csrr %0, mtval;" : "=r"(result));
   return result;
 }
@@ -188,7 +188,10 @@ _cva6_exc_handler(void)
 {
   libmin_printf("EXCEPTION!!!\n");
   libmin_printf("============\n");
-  libmin_printf("MEPC:0x%08x, CAUSE:0x%08x, MTVAL:0x%08x\n", _cva6_get_mepc(), _cva6_get_mcause(), _cva6_get_mtval());
+  libmin_printf("MEPC:0x%016lx, CAUSE:0x%016lx, MTVAL:0x%016lx\n",
+                (unsigned long)_cva6_get_mepc(),
+                (unsigned long)_cva6_get_mcause(),
+                (unsigned long)_cva6_get_mtval());
 
   _cva6_exit(-1);
 }
@@ -399,4 +402,3 @@ libtarg_stop_perf(void)
 #endif
 }
 #endif /* TARGET_PERFHOOKS */
-


### PR DESCRIPTION
### Motivation
- CVA6 target had its exception/vector support disabled and was not routing traps into the C handler, preventing applications from printing and terminating on unexpected exceptions. 
- Exception CSR values were being treated as 32-bit on RV64, truncating useful diagnostic bits.

### Description
- Install a tiny trap entry `_cva6_trap_entry` in `target/cva6-crt0.S` and program `mtvec` in `_start` so all traps are routed into the C exception handler via a direct jump to `_cva6_exc_handler`.
- Re-enable `.bss` clearing at startup in `target/cva6-crt0.S` so runtime globals are deterministic before `main` executes.
- Change CSR accessors in `target/libtarg.c` to return `uint64_t` for `mepc`, `mcause`, and `mtval` on RV64 and print them with full-width formatting using `"%016lx"` and casts to `unsigned long`.
- Keep the behavior of terminating after printing by invoking `_cva6_exit(-1)` from the exception handler so failures are visible and fatal for bringup diagnostics.

### Testing
- Ran `make TARGET=cva6-rv64` to exercise the top-level build helper and verify the modified files are recognized; this completed successfully.
- Attempted to build the `banner` benchmark for `TARGET=cva6-rv64gc` with `make -C banner ...`, which invoked the cross-compile step but failed because the build environment is missing `riscv-none-elf-gcc`, so full compile/link verification could not be completed.
- No automated unit tests were added; the change is exercised by target builds and will print/terminate on real CVA6 traps once a cross-compiler/simulation environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7b9edc148325a64e0ca6dc2375cd)