### PR TITLE
Fix CVA6 linker script to avoid RWX LOAD segment warning

### DIFF
--- a/target/cva6-map.ld
+++ b/target/cva6-map.ld
@@ -21,31 +21,31 @@ SECTIONS
   . = 0x80000000;
   /* . = 0x00100000; */
   _start_text = .;
-  .text.init : { *(.text.init) }
+  .text.init : { *(.text.init) } :text
   . = ALIGN(/* 0x1000*/ 16);
-  .tohost : { *(.tohost) }
+  .tohost : { *(.tohost) } :data
   . = ALIGN(/* 0x1000*/ 16);
-  .uvmif : { *(.uvmif) }
+  .uvmif : { *(.uvmif) } :data
   . = ALIGN(/* 0x1000*/ 16);
-  .text : { *(.text) }
+  .text : { *(.text) } :text
   . = ALIGN(/* 0x1000*/ 16);
-  .text.startup : { *(.text.startup) }
+  .text.startup : { *(.text.startup) } :text
   . = ALIGN(/* 0x1000*/ 16);
   _end_text = .;
   . = ALIGN(/* 0x1000*/ 16);
-  .rodata : { *(.rodata*)}
+  .rodata : { *(.rodata*)} :text
   . = ALIGN(0x8);
   . = ALIGN(/* 0x1000*/ 16);
-  .page_table : { *(.page_table) }
-  .user_stack : { *(.user_stack) }
-  .kernel_data : { *(.kernel_data) }
-  .kernel_stack : { *(.kernel_stack) }
-  .data : { *(.data) }
+  .page_table : { *(.page_table) } :data
+  .user_stack : { *(.user_stack) } :data
+  .kernel_data : { *(.kernel_data) } :data
+  .kernel_stack : { *(.kernel_stack) } :data
+  .data : { *(.data) } :data
   .sdata : {
     __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)
-  }
+  } :data
 
   /* bss segment */
 /*  .sbss : {
@@ -58,7 +58,7 @@ SECTIONS
     _bss_start = .;
     *(.bss)
     _bss_end = .;
-  }
+  } :data
 /*
   .tdata :
   {
@@ -73,4 +73,9 @@ SECTIONS
   }
 */
   _end = .;
+}
+
+PHDRS {
+  text PT_LOAD FLAGS(5); /* R + X */
+  data PT_LOAD FLAGS(6); /* R + W */
 }


### PR DESCRIPTION
### Motivation
- The toolchain emitted a linker warning that `gemm.elf` had a LOAD segment with RWX permissions, which is unsafe and causes spurious warnings during `TARGET=cva6-rv64gc` builds.
- The intent is to separate executable/readonly sections from writable sections so the linker can produce distinct program headers for RX and RW segments.

### Description
- Updated `target/cva6-map.ld` to assign output sections explicitly to program headers using `:text` for executable/RO sections and `:data` for writable sections.
- Added a `PHDRS` block defining separate `text PT_LOAD FLAGS(5)` (R+X) and `data PT_LOAD FLAGS(6)` (R+W) program headers.
- Mapped sections such as `.text.init`, `.text`, `.text.startup`, and `.rodata` to `:text` and sections such as `.tohost`, `.uvmif`, `.data`, `.sdata`, and `.bss` to `:data`.
- The change is localized to the single linker script file `target/cva6-map.ld` and does not alter build rules.

### Testing
- Ran `make TARGET=cva6-rv64gc gemm -j4` which completed successfully in this environment.
- Ran `make TARGET=cva6-rv64gc clean gemm -j4` which completed successfully and removed the prior RWX LOAD segment warning during linking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0104ba0bac8325867272a75da915c3)