### PR TITLE
cva6: align data PT_LOAD to page boundary to avoid RWX LOAD warning

### DIFF
--- a/target/cva6-map.ld
+++ b/target/cva6-map.ld
@@ -35,7 +35,8 @@ SECTIONS
   . = ALIGN(/* 0x1000*/ 16);
   .rodata : { *(.rodata*)} :text
   . = ALIGN(0x8);
-  . = ALIGN(/* 0x1000*/ 16);
+  /* Force next PT_LOAD segment onto a page boundary so text is not merged with writable data. */
+  . = ALIGN(0x1000);
   .page_table : { *(.page_table) } :data
   .user_stack : { *(.user_stack) } :data
   .kernel_data : { *(.kernel_data) } :data


### PR DESCRIPTION
### Motivation
- Prevent the linker from coalescing executable and writable segments into a single RWX `PT_LOAD` (which triggers `ld: warning: ... has a LOAD segment with RWX permissions`).

### Description
- Update `target/cva6-map.ld` to replace the 16-byte alignment before `.page_table` with `ALIGN(0x1000)` and add an explanatory comment so the writable `:data` `PT_LOAD` begins on a 4 KiB page boundary.

### Testing
- Attempted to run `make -C gemm TARGET=cva6-rv64gc clean build` to verify the warning was removed, but the build could not run in this environment because `riscv-none-elf-gcc` is not installed, so automated validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01357203b483258c73bd4851b3c03a)